### PR TITLE
Add slack test

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ func main() {
 }
 
 // blogReminder ブログのリマインダーロジックを実行
-func blogReminder() {
+func blogReminder() error {
 	thisMonday := date.GetThisMonday()
 	configData := config.GetConfigData()
 	allMemberDataList := database.FindAll(configData)
@@ -46,14 +46,21 @@ func blogReminder() {
 	}
 
 	sendText := message.MakeReminderSendText(targetUserList)
-	slack.SendMessage(configData, sendText)
+	err := slack.SendMessage(configData, sendText)
+	if err != nil {
+		return err
+	}
 	if len(errMembers) != 0 {
-		slack.SendMessage(
+		err := slack.SendMessage(
 			configData,
 			message.CreateFailedRSSMessage(errMembers),
 		)
+		if err != nil {
+			return err
+		}
 	}
 	// fmt.Println(sendText)
+	return nil
 }
 
 // blogRegister ブログの登録ロジックを実行
@@ -77,7 +84,7 @@ func blogRegister(_ context.Context, rawParams interface{}) (interface{}, error)
 }
 
 // blogResult ブログ書けたかどうか通知のロジックを実行
-func blogResult() {
+func blogResult() error {
 	lastWeekMonday := date.GetLastWeekMonday()
 	configData := config.GetConfigData()
 	allMemberDataList := database.FindAll(configData)
@@ -90,14 +97,21 @@ func blogResult() {
 
 	database.ResetRequireCount(configData, targetUserList)
 	sendText := message.MakeResultSendText(configData.Blog.MaxBlogQuota, targetUserList)
-	slack.SendMessage(configData, sendText)
+	err := slack.SendMessage(configData, sendText)
+	if err != nil {
+		return err
+	}
 	if len(errMembers) != 0 {
-		slack.SendMessage(
+		err := slack.SendMessage(
 			configData,
 			message.CreateFailedRSSMessage(errMembers),
 		)
+		if err != nil {
+			return err
+		}
 	}
 	// fmt.Println(sendText)
+	return nil
 }
 
 // blogDelete ブログの削除ロジックを実行

--- a/slack/slack.go
+++ b/slack/slack.go
@@ -2,6 +2,7 @@ package slack
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -19,16 +20,30 @@ type SlackParams struct {
 	Text     string
 }
 
+type slackBody struct {
+	Text      string `json:"text"`
+	Channel   string `json:"channel"`
+	LinkNames string `json:"link_names"`
+}
+
 // SendMessage Slackの特定チャンネルにメッセージを投稿する
 func SendMessage(configData config.ConfigData, sendText string) {
 	// JSONとしてパラメータを設定
-	jsonStr := `{"text":"` + sendText + `","channel":"` + configData.Slack.ChannelName + `","link_names":"1"}`
+	body := &slackBody{
+		Text:      sendText,
+		Channel:   configData.Slack.ChannelName,
+		LinkNames: "1",
+	}
+	jsonStr, err := json.Marshal(body)
+	if err != nil {
+		panic("hoge")
+	}
 
 	// 通知を実行する
 	request, newRequestError := http.NewRequest(
 		"POST",
 		configData.Slack.SendAPIURL,
-		bytes.NewBuffer([]byte(jsonStr)),
+		bytes.NewBuffer(jsonStr),
 	)
 	if newRequestError != nil {
 		panic("newRequestErrorのリクエスト作成に失敗しました。")

--- a/slack/slack.go
+++ b/slack/slack.go
@@ -70,12 +70,7 @@ func ParseSlackParams(rawParams interface{}) (result *SlackParams, err error) {
 		return
 	}
 	rawQueryString := tmp["body"].(string)
-	parsed, err := url.QueryUnescape(rawQueryString)
-	if err != nil {
-		err = errors.New("params body unescape failed. body: " + rawQueryString)
-		return
-	}
-	params, err := url.ParseQuery(parsed)
+	params, err := url.ParseQuery(rawQueryString)
 	if err != nil {
 		err = errors.New("params body parse failed. body: " + rawQueryString)
 		return

--- a/slack/slack.go
+++ b/slack/slack.go
@@ -27,7 +27,7 @@ type slackBody struct {
 }
 
 // SendMessage Slackの特定チャンネルにメッセージを投稿する
-func SendMessage(configData config.ConfigData, sendText string) {
+func SendMessage(configData config.ConfigData, sendText string) error {
 	// JSONとしてパラメータを設定
 	body := &slackBody{
 		Text:      sendText,
@@ -36,7 +36,7 @@ func SendMessage(configData config.ConfigData, sendText string) {
 	}
 	jsonStr, err := json.Marshal(body)
 	if err != nil {
-		panic("json文字列の作成に失敗しました。")
+		return errors.New("json文字列の作成に失敗しました。")
 	}
 
 	// 通知を実行する
@@ -46,7 +46,7 @@ func SendMessage(configData config.ConfigData, sendText string) {
 		bytes.NewBuffer(jsonStr),
 	)
 	if newRequestError != nil {
-		panic("newRequestErrorのリクエスト作成に失敗しました。")
+		return errors.New("newRequestErrorのリクエスト作成に失敗しました。")
 	}
 	defer request.Body.Close()
 
@@ -54,10 +54,11 @@ func SendMessage(configData config.ConfigData, sendText string) {
 	client := &http.Client{}
 	response, doSendError := client.Do(request)
 	if doSendError != nil {
-		panic("SendMessageのリクエスト実行に失敗しました。")
+		return errors.New("SendMessageのリクエスト実行に失敗しました。")
 	}
 
 	defer response.Body.Close()
+	return nil
 }
 
 // ParseSlackParams Slackから送られたパラメータをパースする

--- a/slack/slack.go
+++ b/slack/slack.go
@@ -36,7 +36,7 @@ func SendMessage(configData config.ConfigData, sendText string) {
 	}
 	jsonStr, err := json.Marshal(body)
 	if err != nil {
-		panic("hoge")
+		panic("json文字列の作成に失敗しました。")
 	}
 
 	// 通知を実行する

--- a/slack/slack_test.go
+++ b/slack/slack_test.go
@@ -89,22 +89,17 @@ func TestParseSlackParams(t *testing.T) {
 }
 
 func TestSendMessage(t *testing.T) {
-	type body struct {
-		Text      string `json:"text"`
-		Channel   string `json:"channel"`
-		LinkNames string `json:"link_names"`
-	}
 	got := make(map[string]string)
 	h := func(w http.ResponseWriter, r *http.Request) {
 		bodyStr, err := ioutil.ReadAll(r.Body)
 		if err != nil {
 			t.Errorf("Unexpected error = %v", err)
 		}
-		var b body
-		if err := json.Unmarshal(bodyStr, &b); err != nil {
+		var body slackBody
+		if err := json.Unmarshal(bodyStr, &body); err != nil {
 			t.Errorf("Unexpected error = %v", err)
 		}
-		got[b.Channel] = b.Text
+		got[body.Channel] = body.Text
 		w.WriteHeader(http.StatusOK)
 	}
 	testServer := httptest.NewServer(http.HandlerFunc(h))

--- a/slack/slack_test.go
+++ b/slack/slack_test.go
@@ -1,0 +1,83 @@
+package slack
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseSlackParams(t *testing.T) {
+	tests := []struct {
+		name       string
+		rawParams  interface{}
+		wantResult *SlackParams
+		wantErr    bool
+	}{
+		{
+			name: "nobody",
+			rawParams: map[string]interface{}{
+				"key": "value",
+			},
+			wantResult: nil,
+			wantErr:    true,
+		},
+		{
+			name: "invalidUrlEscape",
+			rawParams: map[string]interface{}{
+				"body": "%",
+			},
+			wantResult: nil,
+			wantErr:    true,
+		},
+		{
+			name: "registerBlog",
+			rawParams: map[string]interface{}{
+				"body": "token=mytoken&user_id=user1&user_name=myuser&text=<https://myawesome.blog.com>",
+			},
+			wantResult: &SlackParams{
+				Token:    "mytoken",
+				UserID:   "user1",
+				UserName: "myuser",
+				Text:     "https://myawesome.blog.com",
+			},
+			wantErr: false,
+		},
+		{
+			name: "deleteBlogWithAtSign",
+			rawParams: map[string]interface{}{
+				"body": "token=mytoken&user_id=user1&user_name=myuser&text=@targetuser",
+			},
+			wantResult: &SlackParams{
+				Token:    "mytoken",
+				UserID:   "user1",
+				UserName: "myuser",
+				Text:     "targetuser",
+			},
+			wantErr: false,
+		},
+		{
+			name: "deleteBlogWithoutAtSign",
+			rawParams: map[string]interface{}{
+				"body": "token=mytoken&user_id=user1&user_name=myuser&text=targetuser",
+			},
+			wantResult: &SlackParams{
+				Token:    "mytoken",
+				UserID:   "user1",
+				UserName: "myuser",
+				Text:     "targetuser",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotResult, err := ParseSlackParams(tt.rawParams)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseSlackParams() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(gotResult, tt.wantResult) {
+				t.Errorf("ParseSlackParams() = %v, want %v", gotResult, tt.wantResult)
+			}
+		})
+	}
+}

--- a/slack/slack_test.go
+++ b/slack/slack_test.go
@@ -110,8 +110,9 @@ func TestSendMessage(t *testing.T) {
 		sendText   string
 	}
 	tests := []struct {
-		name string
-		args args
+		name    string
+		args    args
+		wantErr bool
 	}{
 		{
 			name: "normal",
@@ -126,11 +127,29 @@ func TestSendMessage(t *testing.T) {
 				},
 				sendText: "hello slack",
 			},
+			wantErr: false,
+		},
+		{
+			name: "urlParseError",
+			args: args{
+				configData: config.ConfigData{
+					Slack: config.Slack{
+						SendAPIURL:  string(0x31),
+						ChannelName: "",
+					},
+				},
+				sendText: "",
+			},
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			SendMessage(tt.args.configData, tt.args.sendText)
+			err := SendMessage(tt.args.configData, tt.args.sendText)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SendMessage() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
 			if got[tt.args.configData.Slack.ChannelName] != tt.args.sendText {
 				t.Errorf("Got = %v, wantChannel = %s, wantSendText = %s", got, tt.args.configData.Slack.ChannelName, tt.args.sendText)
 			}


### PR DESCRIPTION
## :ticket: Issue
#31 

## :memo: 概要
- slack_test.goにParseSlackParamsとSendMessageのテストを追加
- SendMessageのリファクタリング（json文字列の作成にstructを利用）

## :no_good_man: やってないこと
- SendMessageの異常系テストの実装

## :heavy_check_mark: 動作確認
- [ ] CIのテストが全て問題ない
